### PR TITLE
fix: add dep for postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "7.32.0",
     "eslint-config-next": "11.1.2",
     "jest": "^27.1.1",
+    "postcss": "^8.3.11",
     "sass": "^1.41.1",
     "ts-jest": "^27.0.5",
     "typescript": "4.4.2"


### PR DESCRIPTION
Fixes build error that css is not found so `npm run build` works.